### PR TITLE
Improve frontend layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,18 +1,27 @@
 <template>
   <div id="app">
     <Session @session-created="onSessionCreated" />
+
+    <div v-if="sessionId" class="session-banner">
+      <p>Session Code: <strong>{{ sessionId }}</strong></p>
+      <p v-if="isAdmin">Share this code with participants to join.</p>
+    </div>
+
     <SurveyForm
       v-if="sessionId"
       :sessionId="sessionId"
       :isAdmin="isAdmin"
       @surveys-updated="onSurveysUpdated"
     />
-    <div v-if="sessionId && isAdmin" style="margin-top:20px">
+
+    <div v-if="sessionId && isAdmin" class="admin-tools">
       <p>Responses: {{ surveys.length }}</p>
       <button @click="fetchTeams" :disabled="surveys.length < minResponses">
         Generate Teams
       </button>
+      <p v-if="surveys.length < minResponses" class="hint">Waiting for more responses...</p>
     </div>
+
     <TeamGraph v-if="teams.length" :teams="teams" />
   </div>
 </template>
@@ -107,5 +116,21 @@ input, select {
   margin: 5px;
   border: 1px solid #ddd;
   border-radius: 4px;
+}
+
+.session-banner {
+  margin-bottom: 20px;
+  padding: 10px;
+  background: #f5f5f5;
+  border-radius: 4px;
+}
+
+.admin-tools {
+  margin-top: 20px;
+}
+
+.hint {
+  font-size: 0.9em;
+  color: #888;
 }
 </style>

--- a/frontend/src/components/Session.vue
+++ b/frontend/src/components/Session.vue
@@ -1,8 +1,10 @@
 <template>
-  <div>
+  <div class="session-container">
     <button @click="createSession">Create Session</button>
-    <input v-model="joinId" placeholder="Session code" style="margin-left:10px"/>
-    <button @click="joinSession" style="margin-left:5px">Join</button>
+    <div class="join-group">
+      <input v-model="joinId" placeholder="Enter session code" />
+      <button @click="joinSession">Join</button>
+    </div>
   </div>
 </template>
 
@@ -32,7 +34,14 @@ export default {
 </script>
 
 <style scoped>
-div {
+.session-container {
   margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.join-group {
+  margin-top: 10px;
 }
 </style>

--- a/frontend/src/components/SurveyForm.vue
+++ b/frontend/src/components/SurveyForm.vue
@@ -12,6 +12,7 @@
             {{ opt.label }}
           </option>
         </component>
+        <span v-if="field.type === 'slider'" class="slider-value">{{ survey[field.key] }}</span>
       </div>
       <button type="submit">Submit Survey</button>
     </form>
@@ -130,5 +131,10 @@ select {
 button {
   align-self: center;
   margin-top: 20px;
+}
+
+.slider-value {
+  margin-left: 8px;
+  font-weight: bold;
 }
 </style>

--- a/frontend/src/components/TeamGraph.vue
+++ b/frontend/src/components/TeamGraph.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="graph-container">
     <h2>Teams</h2>
-    <div ref="cy" style="width:100%; height:400px; margin-top:20px; border: 1px solid #ddd; border-radius: 4px;"></div>
+    <div ref="cy" class="graph"></div>
   </div>
 </template>
 
@@ -133,3 +133,17 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.graph-container {
+  margin-top: 30px;
+}
+
+.graph {
+  width: 100%;
+  height: 400px;
+  margin-top: 20px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add session info banner and hints
- clarify session form and slider values
- style graph container

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868eec13a7c8332ba0e1ae824386001