### PR TITLE
Enable ngrok access

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Exposing the app with ngrok
+
+To share the locally running app over the internet you can use `ngrok`.
+Install the additional dependency and run the helper script:
+
+```
+pip install pyngrok
+python run_with_ngrok.py
+```
+The terminal will display a public URL that forwards traffic to your local
+Flask server.
+
 ### Frontend Setup
 
 1. Navigate to the frontend directory:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.25.2
 pandas==2.1.1
 python-dotenv==1.0.0
 redis==4.5.0
+pyngrok==6.0.0

--- a/backend/run_with_ngrok.py
+++ b/backend/run_with_ngrok.py
@@ -1,0 +1,14 @@
+import threading
+from pyngrok import ngrok
+from app import app
+
+if __name__ == "__main__":
+    public_url = ngrok.connect(5000, bind_tls=True).public_url
+    print(f"ngrok tunnel: {public_url}")
+
+    def run_app():
+        app.run(host="0.0.0.0", port=5000)
+
+    thread = threading.Thread(target=run_app)
+    thread.start()
+    thread.join()


### PR DESCRIPTION
## Summary
- add pyngrok to backend requirements
- document how to expose the server with ngrok
- provide a helper script to launch the Flask app through ngrok

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68692bf2f72483329c369b6ec9a1fc8c