### PR TITLE
Improve participant highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Exposing the app with ngrok
+
+To share the locally running app over the internet you can use `ngrok`.
+Install the additional dependency and run the helper script,
+which launches the Flask server and exposes port 5000 through ngrok:
+
+```
+pip install pyngrok
+python run_with_ngrok.py
+```
+The terminal will display a public URL that forwards traffic to your local
+Flask server.
+
 ### Frontend Setup
 
 1. Navigate to the frontend directory:

--- a/backend/app.py
+++ b/backend/app.py
@@ -90,10 +90,12 @@ def submit_survey(sid):
     if missing:
         return jsonify({"error": f"Missing fields: {missing}"}), 400
 
-    # Anonymous mode: assign id & name
+    # Always assign a unique user id if one was not provided
+    idx = len(sess["users"]) + 1
+    data.setdefault("id", f"user_{idx}")
+
+    # In anonymous mode also replace the provided name
     if settings.get("anonymous_mode"):
-        idx        = len(sess["users"]) + 1
-        data["id"] = f"user_{idx}"
         data["name"] = f"User {idx}"
 
     sess["users"].append(data)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.25.2
 pandas==2.1.1
 python-dotenv==1.0.0
 redis==4.5.0
+pyngrok==6.0.0

--- a/backend/run_with_ngrok.py
+++ b/backend/run_with_ngrok.py
@@ -1,0 +1,10 @@
+from pyngrok import ngrok
+from app import app
+
+if __name__ == "__main__":
+    public_url = ngrok.connect(5000, bind_tls=True).public_url
+    print(f"ngrok tunnel: {public_url}")
+
+    # Run the Flask development server in the main thread so the
+    # Werkzeug reloader can install signal handlers without errors.
+    app.run(host="0.0.0.0", port=5000, use_reloader=False)

--- a/frontend/team_sync_front/src/App.vue
+++ b/frontend/team_sync_front/src/App.vue
@@ -62,7 +62,7 @@
           <div v-for="(team, index) in teams" :key="index" class="team-card">
             <h3>Team {{ index + 1 }}</h3>
             <ul>
-              <li v-for="(member, memberIndex) in team.members" :key="memberIndex">
+              <li v-for="(member, memberIndex) in team.members" :key="member.id || member.name || memberIndex">
                 {{ member.name }}
               </li>
             </ul>
@@ -96,10 +96,10 @@
           >
             <h3>Team {{ index + 1 }}</h3>
             <ul>
-              <li 
-                v-for="(member, idx) in team.members" 
-                :key="member.id"
-                :class="{ 
+              <li
+                v-for="(member, idx) in team.members"
+                :key="member.id || member.name || idx"
+                :class="{
                   'current-user': isCurrentUser(member),
                   'anonymous-user': sessionSettings.anonymousMode
                 }"
@@ -425,39 +425,21 @@ export default {
     },
 
     isCurrentUser(member) {
-      const currentUserId = sessionStorage.getItem('currentUserId');
-      console.log('Checking current user:', { 
-        currentUserId, 
-        memberId: member?.id, 
-        memberName: member?.name,
-        anonymousMode: this.sessionSettings.anonymousMode,
-        member: member
-      });
-      
-      if (!currentUserId || !member) {
-        console.log('No current user ID or invalid member');
+      const storedId = sessionStorage.getItem('currentUserId');
+      const storedName = sessionStorage.getItem('currentUserName');
+
+      if (!member) {
         return false;
       }
-      
-      if (this.sessionSettings.anonymousMode) {
-        // In anonymous mode, compare user IDs directly
-        const isMatch = member.id === currentUserId;
-        console.log('Anonymous mode comparison:', { 
-          memberId: member.id, 
-          currentUserId, 
-          isMatch 
-        });
-        return isMatch;
-      } else {
-        // In named mode, compare by name
-        const isMatch = member.name === currentUserId;
-        console.log('Named mode comparison:', { 
-          memberName: member.name, 
-          currentUserId, 
-          isMatch 
-        });
-        return isMatch;
-      }
+
+      const matchId = storedId && member.id && member.id === storedId;
+      const memberName = (member.name || '').trim().toLowerCase();
+      const nameMatch =
+        storedName && memberName === storedName.trim().toLowerCase();
+      const legacyMatch =
+        storedId && memberName === storedId.trim().toLowerCase();
+
+      return matchId || nameMatch || legacyMatch;
     }
   },
   beforeUnmount() {

--- a/frontend/team_sync_front/src/components/SurveyForm.vue
+++ b/frontend/team_sync_front/src/components/SurveyForm.vue
@@ -113,10 +113,20 @@ export default {
     async submitSurvey() {
       try {
         const response = await axios.post(`/api/session/${this.sessionId}/survey`, this.survey);
-        
+
         this.$emit('surveys-updated', response.data);
         this.submitted = true;
-        
+
+        // Persist identifiers for highlighting the current user
+        if (response.data && response.data.user_id) {
+          sessionStorage.setItem('currentUserId', response.data.user_id);
+        }
+
+        if (!this.anonymousMode) {
+          const cleanName = (this.survey.name || '').trim();
+          sessionStorage.setItem('currentUserName', cleanName);
+        }
+
         // Store in sessionStorage that this user has submitted
         sessionStorage.setItem(`survey_submitted_${this.sessionId}`, 'true');
         


### PR DESCRIPTION
## Summary
- assign a user id to every survey submission
- store user name separately in the browser for non-anonymous sessions
- match current user by id or name for highlight

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*
- `npm install --prefix frontend/team_sync_front` *(fails: 403 Forbidden)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68692bf2f72483329c369b6ec9a1fc8c